### PR TITLE
BUGFIX: VideoGroup - remove old belongs_many_many

### DIFF
--- a/code/VideoGroup.php
+++ b/code/VideoGroup.php
@@ -6,14 +6,6 @@
  */
 class VideoGroup extends Page
 {
-
-    /**
-     * @var array
-     */
-    private static $belongs_many_many = array(
-        'Videos' => 'Video'
-    );
-
     /**
      * @var array
      */


### PR DESCRIPTION
no longer using many_many between VideoGroup and Video

fixes #27 
